### PR TITLE
Repo hygiene: .gitignore fix, README alignment, doc links

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,15 +57,13 @@ Smalls-Biggie_neuropsych_report_2025-08-19 copy.pdf
 _02-03_verbal.pdf
 template.typst.md
 _03-03b_examiner_qualifications.qmd
-.gitignore
-.gitignore
 _03-03a_informed_consent.qmd
 _03-00_dsm5_icd10_dx.qmd
 _01-00_nse_referral.qmd
 # scripts
-{{< include _02-*_*_text.qmd
+# NOTE: removed invalid Quarto shortcode (kept here as a comment)
+# {{< include _02-*_*_text.qmd }}
 template_ethan.qmd
-.gitignore
 template_ethan.typ
 template_ethan.pdf
 _00-00_tests.qmd
@@ -85,7 +83,6 @@ fix_conflicts.md
 R/cohere_embed.py
 .venv/
 __pycache__/app.cpython-311.pyc
-.gitignore
 .python-version
 app.py
 figs/

--- a/README.Rmd
+++ b/README.Rmd
@@ -40,7 +40,7 @@ The `neuro2` package is a comprehensive R package for generating professional ne
 
 ### Prerequisites
 
-1.  **R** (version 4.1 or higher)
+1.  **R** (version 4.5 or higher)
 2.  **Quarto** (version 1.4.0 or higher) - [Install Quarto](https://quarto.org/docs/get-started/)
 3.  **CMake** (version 3.10 or higher) - Required for some dependencies
 4.  **webshot2** - For converting tables to images
@@ -60,7 +60,7 @@ pak::pak("brainworkup/neuro2")
 ``` r
 # Core dependencies
 install.packages(c(
-  "dplyr", "tidyr", "ggplot2", "stringr", "here", "glue", "yaml", "quarto ","gt", "gtExtras", "janitor", "R6", "readr", "readxl",
+  "dplyr", "tidyr", "ggplot2", "stringr", "here", "glue", "yaml", "quarto", "gt", "gtExtras", "janitor", "R6", "readr", "readxl",
   "DBI", "duckdb", "arrow", "webshot2"
 ))
 ```
@@ -336,12 +336,12 @@ for (patient in patients) {
 
 ## 📚 Documentation
 
--   [Unified Workflow Guide](UNIFIED_WORKFLOW_README.md) - **Recommended workflow**
--   [Unified Workflow Architecture](unified_workflow_architecture.md) - Technical design
--   [Domain File Generation Workflow](DOMAIN_GENERATION_FIXES.md)
--   [DuckDB Integration Guide](DUCKDB_INTEGRATION_GUIDE.md)
--   [R6 Implementation Guide](R6_IMPLEMENTATION_GUIDE.md)
--   [Dependency Setup Guide](DEPENDENCY_SETUP_GUIDE.md)
+-   [Unified Workflow Guide](UNIFIED_WORKFLOW_README.md) — recommended workflow
+-   [Unified Workflow Architecture](unified_workflow_architecture.md)
+-   [Workflow Guide](WORKFLOW.md) and [Workflow Run Notes](WORKFLOW_RUN.md)
+-   [Domain Generation Fixes](DOMAIN_GENERATION_FIXES.md)
+-   [Integrated Workflow Fixes](INTEGRATED_WORKFLOW_FIXES.md)
+-   [Neuropsych Score Types](docs/NEUROPSYCH_SCORE_TYPES.md)
 
 ## 🤝 Contributing
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ DuckDB/Parquet, and beautiful typesetting with Quarto/Typst.
 
 ### Prerequisites
 
-1.  **R** (version 4.1 or higher)
+1.  **R** (version 4.5 or higher)
 2.  **Quarto** (version 1.4.0 or higher) - [Install
     Quarto](https://quarto.org/docs/get-started/)
 3.  **CMake** (version 3.10 or higher) - Required for some dependencies
@@ -333,14 +333,12 @@ for (patient in patients) {
 
 ## 📚 Documentation
 
-- [Unified Workflow Guide](UNIFIED_WORKFLOW_README.md) - **Recommended
-  workflow**
-- [Unified Workflow Architecture](unified_workflow_architecture.md) -
-  Technical design
-- [Domain File Generation Workflow](DOMAIN_GENERATION_FIXES.md)
-- [DuckDB Integration Guide](DUCKDB_INTEGRATION_GUIDE.md)
-- [R6 Implementation Guide](R6_IMPLEMENTATION_GUIDE.md)
-- [Dependency Setup Guide](DEPENDENCY_SETUP_GUIDE.md)
+- [Unified Workflow Guide](UNIFIED_WORKFLOW_README.md) — Recommended workflow
+- [Unified Workflow Architecture](unified_workflow_architecture.md) — Technical design
+- [Workflow Guide](WORKFLOW.md) and [Workflow Run Notes](WORKFLOW_RUN.md)
+- [Domain Generation Fixes](DOMAIN_GENERATION_FIXES.md)
+- [Integrated Workflow Fixes](INTEGRATED_WORKFLOW_FIXES.md)
+- [Neuropsych Score Types](docs/NEUROPSYCH_SCORE_TYPES.md)
 
 ## 🤝 Contributing
 

--- a/README.qmd
+++ b/README.qmd
@@ -38,7 +38,7 @@ DuckDB/Parquet, and beautiful typesetting with Quarto/Typst.
 
 ### Prerequisites
 
-1.  **R** (version 4.1 or higher)
+1.  **R** (version 4.5 or higher)
 2.  **Quarto** (version 1.4.0 or higher) - [Install
     Quarto](https://quarto.org/docs/get-started/)
 3.  **CMake** (version 3.10 or higher) - Required for some dependencies
@@ -333,14 +333,12 @@ for (patient in patients) {
 
 ## 📚 Documentation
 
-- [Unified Workflow Guide](UNIFIED_WORKFLOW_README.md) - **Recommended
-  workflow**
-- [Unified Workflow Architecture](unified_workflow_architecture.md) -
-  Technical design
-- [Domain File Generation Workflow](DOMAIN_GENERATION_FIXES.md)
-- [DuckDB Integration Guide](DUCKDB_INTEGRATION_GUIDE.md)
-- [R6 Implementation Guide](R6_IMPLEMENTATION_GUIDE.md)
-- [Dependency Setup Guide](DEPENDENCY_SETUP_GUIDE.md)
+- [Unified Workflow Guide](UNIFIED_WORKFLOW_README.md) — recommended workflow
+- [Unified Workflow Architecture](unified_workflow_architecture.md)
+- [Workflow Guide](WORKFLOW.md) and [Workflow Run Notes](WORKFLOW_RUN.md)
+- [Domain Generation Fixes](DOMAIN_GENERATION_FIXES.md)
+- [Integrated Workflow Fixes](INTEGRATED_WORKFLOW_FIXES.md)
+- [Neuropsych Score Types](docs/NEUROPSYCH_SCORE_TYPES.md)
 
 ## 🤝 Contributing
 


### PR DESCRIPTION
- Remove invalid Quarto shortcode from .gitignore and dedupe entries
- Align README R version to 4.5+ to match DESCRIPTION
- Fix documentation links to existing files