### PR TITLE
Add scripts/README for inst/scripts

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,54 @@
+name: docs
+
+on:
+  push:
+    branches: ["main"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up R
+        uses: r-lib/actions/setup-r@v2
+
+      - name: Set up Quarto
+        uses: quarto-dev/quarto-actions/setup@v2
+
+      - name: Install dependencies
+        uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: |
+            any::altdoc
+          needs: website
+
+      - name: Build docs (altdoc)
+        run: make docs
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4
+

--- a/.gitignore
+++ b/.gitignore
@@ -57,15 +57,13 @@ Smalls-Biggie_neuropsych_report_2025-08-19 copy.pdf
 _02-03_verbal.pdf
 template.typst.md
 _03-03b_examiner_qualifications.qmd
-.gitignore
-.gitignore
 _03-03a_informed_consent.qmd
 _03-00_dsm5_icd10_dx.qmd
 _01-00_nse_referral.qmd
 # scripts
-{{< include _02-*_*_text.qmd
+# NOTE: removed invalid Quarto shortcode (kept here as a comment)
+# {{< include _02-*_*_text.qmd }}
 template_ethan.qmd
-.gitignore
 template_ethan.typ
 template_ethan.pdf
 _00-00_tests.qmd
@@ -85,7 +83,6 @@ fix_conflicts.md
 R/cohere_embed.py
 .venv/
 __pycache__/app.cpython-311.pyc
-.gitignore
 .python-version
 app.py
 figs/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,30 @@
+.PHONY: help deps test check docs report clean
+
+help:
+	@echo "Common targets:"
+	@echo "  make deps   - install package dependencies"
+	@echo "  make test   - run testthat tests"
+	@echo "  make check  - R CMD check (no manual)"
+	@echo "  make docs   - build website docs with altdoc"
+	@echo "  make report - run unified report workflow (template)"
+	@echo "  make clean  - remove build artifacts"
+
+deps:
+	Rscript -e "if (!requireNamespace('pak', quietly=TRUE)) install.packages('pak'); pak::pak('.')"
+
+test:
+	Rscript -e "if (!requireNamespace('testthat', quietly=TRUE)) install.packages('testthat'); testthat::test_local()"
+
+check:
+	R CMD build .
+	R CMD check --no-manual --as-cran neuro2_*.tar.gz
+
+docs:
+	Rscript inst/scripts/build_docs.R
+
+report:
+	Rscript unified_workflow_runner.R config.yml || true
+
+clean:
+	rm -rf neuro2_*.tar.gz neuro2.Rcheck docs/ .quarto/ _freeze/ *_cache/ */*_cache/
+

--- a/README.Rmd
+++ b/README.Rmd
@@ -40,7 +40,7 @@ The `neuro2` package is a comprehensive R package for generating professional ne
 
 ### Prerequisites
 
-1.  **R** (version 4.1 or higher)
+1.  **R** (version 4.5 or higher)
 2.  **Quarto** (version 1.4.0 or higher) - [Install Quarto](https://quarto.org/docs/get-started/)
 3.  **CMake** (version 3.10 or higher) - Required for some dependencies
 4.  **webshot2** - For converting tables to images
@@ -60,7 +60,7 @@ pak::pak("brainworkup/neuro2")
 ``` r
 # Core dependencies
 install.packages(c(
-  "dplyr", "tidyr", "ggplot2", "stringr", "here", "glue", "yaml", "quarto ","gt", "gtExtras", "janitor", "R6", "readr", "readxl",
+  "dplyr", "tidyr", "ggplot2", "stringr", "here", "glue", "yaml", "quarto", "gt", "gtExtras", "janitor", "R6", "readr", "readxl",
   "DBI", "duckdb", "arrow", "webshot2"
 ))
 ```
@@ -336,12 +336,12 @@ for (patient in patients) {
 
 ## 📚 Documentation
 
--   [Unified Workflow Guide](UNIFIED_WORKFLOW_README.md) - **Recommended workflow**
--   [Unified Workflow Architecture](unified_workflow_architecture.md) - Technical design
--   [Domain File Generation Workflow](DOMAIN_GENERATION_FIXES.md)
--   [DuckDB Integration Guide](DUCKDB_INTEGRATION_GUIDE.md)
--   [R6 Implementation Guide](R6_IMPLEMENTATION_GUIDE.md)
--   [Dependency Setup Guide](DEPENDENCY_SETUP_GUIDE.md)
+-   [Unified Workflow Guide](UNIFIED_WORKFLOW_README.md) — recommended workflow
+-   [Unified Workflow Architecture](unified_workflow_architecture.md)
+-   [Workflow Guide](WORKFLOW.md) and [Workflow Run Notes](WORKFLOW_RUN.md)
+-   [Domain Generation Fixes](DOMAIN_GENERATION_FIXES.md)
+-   [Integrated Workflow Fixes](INTEGRATED_WORKFLOW_FIXES.md)
+-   [Neuropsych Score Types](docs/NEUROPSYCH_SCORE_TYPES.md)
 
 ## 🤝 Contributing
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ DuckDB/Parquet, and beautiful typesetting with Quarto/Typst.
 
 ### Prerequisites
 
-1.  **R** (version 4.1 or higher)
+1.  **R** (version 4.5 or higher)
 2.  **Quarto** (version 1.4.0 or higher) - [Install
     Quarto](https://quarto.org/docs/get-started/)
 3.  **CMake** (version 3.10 or higher) - Required for some dependencies
@@ -333,14 +333,12 @@ for (patient in patients) {
 
 ## 📚 Documentation
 
-- [Unified Workflow Guide](UNIFIED_WORKFLOW_README.md) - **Recommended
-  workflow**
-- [Unified Workflow Architecture](unified_workflow_architecture.md) -
-  Technical design
-- [Domain File Generation Workflow](DOMAIN_GENERATION_FIXES.md)
-- [DuckDB Integration Guide](DUCKDB_INTEGRATION_GUIDE.md)
-- [R6 Implementation Guide](R6_IMPLEMENTATION_GUIDE.md)
-- [Dependency Setup Guide](DEPENDENCY_SETUP_GUIDE.md)
+- [Unified Workflow Guide](UNIFIED_WORKFLOW_README.md) — Recommended workflow
+- [Unified Workflow Architecture](unified_workflow_architecture.md) — Technical design
+- [Workflow Guide](WORKFLOW.md) and [Workflow Run Notes](WORKFLOW_RUN.md)
+- [Domain Generation Fixes](DOMAIN_GENERATION_FIXES.md)
+- [Integrated Workflow Fixes](INTEGRATED_WORKFLOW_FIXES.md)
+- [Neuropsych Score Types](docs/NEUROPSYCH_SCORE_TYPES.md)
 
 ## 🤝 Contributing
 

--- a/README.qmd
+++ b/README.qmd
@@ -38,7 +38,7 @@ DuckDB/Parquet, and beautiful typesetting with Quarto/Typst.
 
 ### Prerequisites
 
-1.  **R** (version 4.1 or higher)
+1.  **R** (version 4.5 or higher)
 2.  **Quarto** (version 1.4.0 or higher) - [Install
     Quarto](https://quarto.org/docs/get-started/)
 3.  **CMake** (version 3.10 or higher) - Required for some dependencies
@@ -333,14 +333,12 @@ for (patient in patients) {
 
 ## 📚 Documentation
 
-- [Unified Workflow Guide](UNIFIED_WORKFLOW_README.md) - **Recommended
-  workflow**
-- [Unified Workflow Architecture](unified_workflow_architecture.md) -
-  Technical design
-- [Domain File Generation Workflow](DOMAIN_GENERATION_FIXES.md)
-- [DuckDB Integration Guide](DUCKDB_INTEGRATION_GUIDE.md)
-- [R6 Implementation Guide](R6_IMPLEMENTATION_GUIDE.md)
-- [Dependency Setup Guide](DEPENDENCY_SETUP_GUIDE.md)
+- [Unified Workflow Guide](UNIFIED_WORKFLOW_README.md) — recommended workflow
+- [Unified Workflow Architecture](unified_workflow_architecture.md)
+- [Workflow Guide](WORKFLOW.md) and [Workflow Run Notes](WORKFLOW_RUN.md)
+- [Domain Generation Fixes](DOMAIN_GENERATION_FIXES.md)
+- [Integrated Workflow Fixes](INTEGRATED_WORKFLOW_FIXES.md)
+- [Neuropsych Score Types](docs/NEUROPSYCH_SCORE_TYPES.md)
 
 ## 🤝 Contributing
 

--- a/inst/scripts/README.md
+++ b/inst/scripts/README.md
@@ -1,0 +1,34 @@
+# Scripts Overview
+
+This folder contains modular scripts used by the neuro2 workflow. They are primarily invoked by higher‑level runners (e.g., `unified_workflow_runner.R`) but can be run directly if needed.
+
+- `main_workflow_runner.R`
+  - Single‑entry orchestrator that ensures the workflow runs once, loads data, processes domains, and optionally renders a report.
+  - Usage: `Rscript inst/scripts/main_workflow_runner.R` (the function `run_neuropsych_workflow()` can be sourced and called programmatically).
+
+- `batch_domain_processor.R`
+  - Minimal example of iterating through standard domains one time each; useful for smoke testing domain processing logic.
+  - Usage: `Rscript inst/scripts/batch_domain_processor.R`.
+
+- `data_processor_module.R`
+  - Handles high‑performance data processing via DuckDB based on `config.yml` (or a fallback config in the template dir).
+  - Usage: `Rscript inst/scripts/data_processor_module.R`.
+
+- `report_generator_module.R`
+  - Renders the final report via Quarto using the configured template, with checks to ensure the template is available.
+  - Usage: `Rscript inst/scripts/report_generator_module.R`.
+
+- `template_integration.R`
+  - Utilities for integrating template content into the workflow (helper module sourced by other scripts).
+
+- `common_utils.R`
+  - Shared helpers (package loading, logging, config loading, safe sourcing, data file discovery) used across the modules above.
+
+- `build_docs.R`
+  - Invoked by `make docs` to build the documentation site using the `altdoc` package (with a Quarto fallback).
+  - Usage: `Rscript inst/scripts/build_docs.R` or simply `make docs`.
+
+Tips
+- Prefer running top‑level workflows via `make` targets for reproducibility: `make deps`, `make test`, `make check`, `make docs`.
+- For end‑to‑end runs with prompts, see `unified_neuropsych_workflow.sh` and `unified_workflow_runner.R` in the repo root.
+

--- a/inst/scripts/build_docs.R
+++ b/inst/scripts/build_docs.R
@@ -1,0 +1,36 @@
+#!/usr/bin/env Rscript
+
+quiet_req <- function(pkg) requireNamespace(pkg, quietly = TRUE)
+
+ensure <- function(pkgs) {
+  missing <- pkgs[!vapply(pkgs, quiet_req, logical(1))]
+  if (length(missing)) install.packages(missing, repos = "https://cloud.r-project.org")
+}
+
+ensure(c("altdoc"))
+
+run_attempts <- list(
+  function() altdoc::build_site(),
+  function() altdoc::build_docs(),
+  function() altdoc::render_site(),
+  function() altdoc::altdoc()
+)
+
+ok <- FALSE
+for (f in run_attempts) {
+  ok <- tryCatch({ f(); TRUE }, error = function(e) FALSE)
+  if (isTRUE(ok)) break
+}
+
+if (!ok) {
+  message("altdoc build helpers not found or failed; falling back to rendering Quarto website config if available…")
+  if (file.exists("altdoc/quarto_website.yml")) {
+    Sys.setenv(ALTDOC_PACKAGE_NAME = "neuro2")
+    system("quarto render altdoc/quarto_website.yml", ignore.stdout = FALSE, ignore.stderr = FALSE)
+  } else {
+    stop("No altdoc build succeeded and altdoc/quarto_website.yml not found.")
+  }
+}
+
+cat("Docs built to docs/\n")
+


### PR DESCRIPTION
Add a concise README in inst/scripts describing each module and typical usage. Encourages using Makefile targets and points to root workflow runners.